### PR TITLE
add world positions as new attribute for particles collision detection + fix particles collide with other added models again

### DIFF
--- a/src/js/3d/coolerParticles.js
+++ b/src/js/3d/coolerParticles.js
@@ -13,6 +13,7 @@ export function createCoolerParticles(coolerObject) {
   const particleCount = 500
   const particlesGeometry = new THREE.BufferGeometry()
   const positions = new Float32Array(particleCount * 3)
+  const worldPositions = new Float32Array(particleCount * 3)
   const velocities = new Float32Array(particleCount * 3)
   const lifetimes = new Float32Array(particleCount)
   const maxLifetime = new Float32Array(particleCount)
@@ -22,6 +23,7 @@ export function createCoolerParticles(coolerObject) {
     initCoolerParticleProps(
       i,
       positions,
+      worldPositions,
       velocities,
       lifetimes,
       maxLifetime,
@@ -32,6 +34,10 @@ export function createCoolerParticles(coolerObject) {
   particlesGeometry.setAttribute(
     'position',
     new THREE.BufferAttribute(positions, 3)
+  )
+  particlesGeometry.setAttribute(
+    'worldPosition',
+    new THREE.BufferAttribute(worldPositions, 3)
   )
   particlesGeometry.setAttribute(
     'velocity',
@@ -69,6 +75,7 @@ export function updateCoolerParticles() {
   particleSystems.forEach((particleData) => {
     const geometry = particleData.geometry
     const positions = geometry.attributes.position.array
+    const worldPositions = geometry.attributes.worldPosition.array
     const velocities = geometry.attributes.velocity.array
     const lifetimes = geometry.attributes.lifetime.array
     const maxLifetime = geometry.attributes.maxLifetime.array
@@ -84,6 +91,7 @@ export function updateCoolerParticles() {
         initCoolerParticleProps(
           particleIndex,
           positions,
+          worldPositions,
           velocities,
           lifetimes,
           maxLifetime,
@@ -111,6 +119,11 @@ export function updateCoolerParticles() {
       // Convert particle position from local cooler space to world space
       const worldPosition = particlePosition.clone()
       particleData.cooler.localToWorld(worldPosition)
+
+      // Store current world positions for other uses
+      worldPositions[i] = worldPosition['x']
+      worldPositions[i + 1] = worldPosition['y']
+      worldPositions[i + 2] = worldPosition['z']
 
       // Set up raycaster from particle position
       const rayDirection = new THREE.Vector3(
@@ -150,6 +163,7 @@ export function updateCoolerParticles() {
 
     geometry.attributes.color.needsUpdate = true
     geometry.attributes.position.needsUpdate = true
+    geometry.attributes.worldPosition.needsUpdate = true
     geometry.attributes.lifetime.needsUpdate = true
     geometry.attributes.maxLifetime.needsUpdate = true
   })
@@ -158,6 +172,7 @@ export function updateCoolerParticles() {
 export function initCoolerParticleProps(
   index,
   positions,
+  worldPositions,
   velocities,
   lifetimes,
   maxLifetime,
@@ -167,6 +182,10 @@ export function initCoolerParticleProps(
   positions[index * 3] = 0 // x no offset
   positions[index * 3 + 1] = (Math.random() - 0.5) * 0.2 + 20 // y offset
   positions[index * 3 + 2] = (Math.random() - 0.5) * 40 // z offset
+
+  worldPositions[index * 3] = 0
+  worldPositions[index * 3 + 1] = 0
+  worldPositions[index * 3 + 2] = 0 // initialy set world position to 0
 
   // Initial velocities
   velocities[index * 3] = Math.random() * 2 // main flow direction (along X-axis)

--- a/src/js/3d/coolerParticles.js
+++ b/src/js/3d/coolerParticles.js
@@ -134,11 +134,15 @@ export function updateCoolerParticles() {
 
       raycasterCollision.set(worldPosition, rayDirection)
 
-      // Get all objects except the cooler itself and particles
+      // Get all objects except the cooler itself
       const filteredObjects = models.filter(
         (obj) => obj !== particleData.cooler
       )
-      const objectsToTest = [...filteredObjects, floor, ...walls]
+      // Take only the object itself without its particles if present
+      const filteredObjectsMeshes = filteredObjects.map((obj) =>
+        obj.getObjectByProperty('type', 'Mesh')
+      )
+      const objectsToTest = [...filteredObjectsMeshes, floor, ...walls]
 
       const intersects = raycasterCollision.intersectObjects(
         objectsToTest,

--- a/src/js/3d/particleCollisions.js
+++ b/src/js/3d/particleCollisions.js
@@ -79,17 +79,17 @@ function handleCollision(
   const coolerColors = coolerGeometry.attributes.color.array
 
   // Rember to multiply indexes by 3 as colors are defined 3 dimensional vectors
-  rackColors[rackParticleIndex * 3] = 1.0 // Red
-  rackColors[rackParticleIndex * 3 + 1] = 0.5 // Yellow
-  rackColors[rackParticleIndex * 3 + 2] = 0.0 // Blue
+  rackColors[rackParticleIndex] = 1.0 // Red
+  rackColors[rackParticleIndex + 1] = 0.5 // Yellow
+  rackColors[rackParticleIndex + 2] = 0.0 // Blue
 
-  coolerColors[coolerParticleIndex * 3] = 1.0 // Red
-  coolerColors[coolerParticleIndex * 3 + 1] = 0.5 // Yellow
-  coolerColors[coolerParticleIndex * 3 + 2] = 0.0 // Blue
+  coolerColors[coolerParticleIndex] = 1.0 // Red
+  coolerColors[coolerParticleIndex + 1] = 0.5 // Yellow
+  coolerColors[coolerParticleIndex + 2] = 0.0 // Blue
 
   // Reduce maxLifetimes to avoid accumulation
-  rackMaxLifetimes[rackParticleIndex] *= 0.9
-  coolerMaxLifetimes[coolerParticleIndex] *= 0.9
+  rackMaxLifetimes[rackParticleIndex / 3] *= 0.9
+  coolerMaxLifetimes[coolerParticleIndex / 3] *= 0.9
 
   rackGeometry.attributes.maxLifetime.needsUpdate = true
   coolerGeometry.attributes.maxLifetime.needsUpdate = true

--- a/src/js/3d/particleCollisions.js
+++ b/src/js/3d/particleCollisions.js
@@ -15,34 +15,8 @@ function checkCollisionsBetweenSystems(rackData, coolerData) {
   const rackGeometry = rackData.geometry
   const coolerGeometry = coolerData.geometry
 
-  const rackPositions = rackGeometry.attributes.position.array
-  const coolerPositions = coolerGeometry.attributes.position.array
-
-  // Convert rack positions to world space
-  const rackWorldPositions = []
-  for (let i = 0; i < rackPositions.length; i += 3) {
-    const localPos = new THREE.Vector3(
-      rackPositions[i],
-      rackPositions[i + 1],
-      rackPositions[i + 2]
-    )
-    const worldPos = localPos.clone()
-    rackData.rack.localToWorld(worldPos)
-    rackWorldPositions.push(worldPos)
-  }
-
-  // Convert cooler positions to world space
-  const coolerWorldPositions = []
-  for (let i = 0; i < coolerPositions.length; i += 3) {
-    const localPos = new THREE.Vector3(
-      coolerPositions[i],
-      coolerPositions[i + 1],
-      coolerPositions[i + 2]
-    )
-    const worldPos = localPos.clone()
-    coolerData.cooler.localToWorld(worldPos)
-    coolerWorldPositions.push(worldPos)
-  }
+  const rackWorldPositions = rackGeometry.attributes.worldPosition.array
+  const coolerWorldPositions = coolerGeometry.attributes.worldPosition.array
 
   // Check for collisions between each rack particle and cooler particle
   const collisionDistance = 0.1 // Same as used in individual particle collision detection
@@ -50,20 +24,32 @@ function checkCollisionsBetweenSystems(rackData, coolerData) {
   // Track which rack particles have already collided this frame
   const collidedRackParticles = new Set()
 
-  for (let rackIndex = 0; rackIndex < rackWorldPositions.length; rackIndex++) {
+  for (
+    let rackIndex = 0;
+    rackIndex < rackWorldPositions.length;
+    rackIndex += 3
+  ) {
     // Skip if this rack particle already collided
     if (collidedRackParticles.has(rackIndex)) {
       continue
     }
 
-    const rackPos = rackWorldPositions[rackIndex]
+    const rackPos = new THREE.Vector3(
+      rackWorldPositions[rackIndex],
+      rackWorldPositions[rackIndex + 1],
+      rackWorldPositions[rackIndex + 2]
+    )
 
     for (
       let coolerIndex = 0;
       coolerIndex < coolerWorldPositions.length;
-      coolerIndex++
+      coolerIndex += 3
     ) {
-      const coolerPos = coolerWorldPositions[coolerIndex]
+      const coolerPos = new THREE.Vector3(
+        coolerWorldPositions[coolerIndex],
+        coolerWorldPositions[coolerIndex + 1],
+        coolerWorldPositions[coolerIndex + 2]
+      )
       const distance = rackPos.distanceTo(coolerPos)
 
       if (distance < collisionDistance) {

--- a/src/js/3d/rackParticles.js
+++ b/src/js/3d/rackParticles.js
@@ -135,9 +135,13 @@ export function updateRackParticles() {
 
       raycasterCollision.set(worldPosition, rayDirection)
 
-      // Get all objects except the rack itself and particles
+      // Get all objects except the rack itself
       const filteredObjects = models.filter((obj) => obj !== particleData.rack)
-      const objectsToTest = [...filteredObjects, floor, ...walls]
+      // Take only the object itself without its particles if present
+      const filteredObjectsMeshes = filteredObjects.map((obj) =>
+        obj.getObjectByProperty('type', 'Mesh')
+      )
+      const objectsToTest = [...filteredObjectsMeshes, floor, ...walls]
 
       const intersects = raycasterCollision.intersectObjects(
         objectsToTest,

--- a/src/js/3d/rackParticles.js
+++ b/src/js/3d/rackParticles.js
@@ -6,13 +6,14 @@ export let particleSystems = []
 
 // constant low velocity along x due to small initial velocity
 // velocity increased by 50% at every update along y (hot particles going up)
-// velocity reduced at every update along z (backwards, on the main direction due to friction)
+// velocity reduced at every update along z (backwards on the main direction, due to friction)
 const accelerations = [1, 1.2, 0.3]
 
 export function createRackParticles(rackObject) {
   const particleCount = 250
   const particlesGeometry = new THREE.BufferGeometry()
   const positions = new Float32Array(particleCount * 3)
+  const worldPositions = new Float32Array(particleCount * 3)
   const velocities = new Float32Array(particleCount * 3)
   const lifetimes = new Float32Array(particleCount)
   const maxLifetime = new Float32Array(particleCount)
@@ -22,6 +23,7 @@ export function createRackParticles(rackObject) {
     initRackParticleProps(
       i,
       positions,
+      worldPositions,
       velocities,
       lifetimes,
       maxLifetime,
@@ -32,6 +34,10 @@ export function createRackParticles(rackObject) {
   particlesGeometry.setAttribute(
     'position',
     new THREE.BufferAttribute(positions, 3)
+  )
+  particlesGeometry.setAttribute(
+    'worldPosition',
+    new THREE.BufferAttribute(worldPositions, 3)
   )
   particlesGeometry.setAttribute(
     'velocity',
@@ -70,6 +76,7 @@ export function updateRackParticles() {
   particleSystems.forEach((particleData) => {
     const geometry = particleData.geometry
     const positions = geometry.attributes.position.array
+    const worldPositions = geometry.attributes.worldPosition.array
     const velocities = geometry.attributes.velocity.array
     const lifetimes = geometry.attributes.lifetime.array
     const maxLifetime = geometry.attributes.maxLifetime.array
@@ -85,6 +92,7 @@ export function updateRackParticles() {
         initRackParticleProps(
           particleIndex,
           positions,
+          worldPositions,
           velocities,
           lifetimes,
           maxLifetime,
@@ -112,6 +120,11 @@ export function updateRackParticles() {
       // Convert particle position from local rack space to world space
       const worldPosition = particlePosition.clone()
       particleData.rack.localToWorld(worldPosition)
+
+      // Store current world positions for other uses
+      worldPositions[i] = worldPosition['x']
+      worldPositions[i + 1] = worldPosition['y']
+      worldPositions[i + 2] = worldPosition['z']
 
       // Set up raycaster from particle position
       const rayDirection = new THREE.Vector3(
@@ -149,6 +162,7 @@ export function updateRackParticles() {
 
     geometry.attributes.color.needsUpdate = true
     geometry.attributes.position.needsUpdate = true
+    geometry.attributes.worldPosition.needsUpdate = true
     geometry.attributes.lifetime.needsUpdate = true
     geometry.attributes.maxLifetime.needsUpdate = true
   })
@@ -157,6 +171,7 @@ export function updateRackParticles() {
 export function initRackParticleProps(
   index,
   positions,
+  worldPositions,
   velocities,
   lifetimes,
   maxLifetime,
@@ -166,6 +181,10 @@ export function initRackParticleProps(
   positions[index * 3] = (Math.random() - 0.5) * 0.5 // x initial offset
   positions[index * 3 + 1] = (Math.random() - 0.5) * 2.5 // y offset
   positions[index * 3 + 2] = -(Math.random() - 0.5 + 0.8) // z offset
+
+  worldPositions[index * 3] = 0
+  worldPositions[index * 3 + 1] = 0
+  worldPositions[index * 3 + 2] = 0 // initialy set world position to 0
 
   // Initial velocities
   velocities[index * 3] = (Math.random() - 0.5) * 0.002 // slightly random along x

--- a/src/js/3d/scene3d.js
+++ b/src/js/3d/scene3d.js
@@ -76,6 +76,7 @@ export function init3D() {
   floor = new THREE.Mesh(floorGeometry, floorMaterial)
   floor.rotation.x = -Math.PI / 2
   floor.position.y = 0
+  floor.name = 'floor'
   scene.add(floor)
 
   // Raycaster and mouse initialization


### PR DESCRIPTION
Particles's world position are stored as attribute of the particle geometry so that can be used for collision detection. Otherwise a transformation from local to world was made per each particle in each pair of cooler-rack present in the scene. Now it is done only once per each update.

Also a fix was made to let the particles from one object collide again with all other objects. This can be tweaked in the future to reduce computation burden if we don't need collision detection on a specific type of object. 