### PR TITLE
fix loading spinner

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
       </div>
       <canvas id="canvas3D"></canvas>
     </div>
-    <div id="loading-indicator" style="display: none;">
+    <div id="loading-indicator" style="display: none">
       <div class="loading-content">
         <div class="spinner"></div>
         <div>Loading model...</div>

--- a/index.html
+++ b/index.html
@@ -134,6 +134,12 @@
       </div>
       <canvas id="canvas3D"></canvas>
     </div>
+    <div id="loading-indicator" style="display: none;">
+      <div class="loading-content">
+        <div class="spinner"></div>
+        <div>Loading model...</div>
+      </div>
+    </div>
     <script type="module" src="src/js/main.js"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1281,11 +1281,14 @@
       "license": "MIT"
     },
     "node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -2048,14 +2051,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2102,18 +2105,18 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.1.tgz",
-      "integrity": "sha512-yJ+Mp7OyV+4S+afWo+QyoL9jFWD11QFH0i5i7JypnfTcA1rmgxCbiA8WwAICDEtZ1Z1hzrVhN8R8rGTqkTY8ZQ==",
+      "version": "7.1.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.9.tgz",
+      "integrity": "sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
-        "fdir": "^6.4.6",
+        "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
         "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.14"
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"

--- a/src/js/3d/3dObjects.js
+++ b/src/js/3d/3dObjects.js
@@ -11,6 +11,21 @@ import {
 import { addAttractorToRack, attractors } from './attractors.js'
 import { scene, models, raycasterMouse, transformControls } from './scene3d.js'
 
+const loadingManager = new THREE.LoadingManager()
+
+loadingManager.onStart = function() {
+  showLoadingIndicator()
+}
+
+loadingManager.onLoad = function() {
+  hideLoadingIndicator()
+}
+
+loadingManager.onError = function(url) {
+  console.error('Error loading:', url)
+  hideLoadingIndicator()
+}
+
 /**
  * addObjectToScene loads a 3D object (OBJ format) by its model name.
  *
@@ -31,7 +46,7 @@ export function addObjectToScene(model) {
     roughness: 0.7, // How rough the surface is (0 = smooth, 1 = rough)
   })
 
-  const objLoader = new OBJLoader()
+  const objLoader = new OBJLoader(loadingManager)
 
   objLoader.load(
     `${model}.obj`,
@@ -61,13 +76,6 @@ export function addObjectToScene(model) {
       }
       scene.add(object)
       models.push(object)
-      hideLoadingIndicator()
-    },
-    showLoadingIndicator(),
-
-    // onError callback
-    function (error) {
-      console.error(`Error loading ${model}:`, error)
       hideLoadingIndicator()
     }
   )

--- a/src/js/3d/3dObjects.js
+++ b/src/js/3d/3dObjects.js
@@ -13,15 +13,15 @@ import { scene, models, raycasterMouse, transformControls } from './scene3d.js'
 
 const loadingManager = new THREE.LoadingManager()
 
-loadingManager.onStart = function() {
+loadingManager.onStart = function () {
   showLoadingIndicator()
 }
 
-loadingManager.onLoad = function() {
+loadingManager.onLoad = function () {
   hideLoadingIndicator()
 }
 
-loadingManager.onError = function(url) {
+loadingManager.onError = function (url) {
   console.error('Error loading:', url)
   hideLoadingIndicator()
 }

--- a/src/js/3d/3dObjects.js
+++ b/src/js/3d/3dObjects.js
@@ -34,10 +34,14 @@ loadingManager.onError = function(url) {
  */
 export function addObjectToScene(model) {
   console.log(model)
-  
+
+  if (!model) {
+    console.warn('No model specified, skip loading!')
+    return
+  }
   activeLoads++
   showLoadingIndicator()
-  
+
   // Use a material that responds to light
   let material_obj = new THREE.MeshStandardMaterial({
     color: 0x6e6e6e, // Gray color
@@ -95,48 +99,10 @@ export function addObjectToScene(model) {
 
 // Helper functions for the loading UI
 function showLoadingIndicator() {
-  let indicator = document.getElementById('loading-indicator')
-  if (!indicator) {
-    indicator = document.createElement('div')
-    indicator.id = 'loading-indicator'
-    indicator.innerHTML = `
-      <div style="
-        position: fixed
-        top: 50%
-        left: 50%
-        transform: translate(-50%, -50%)
-        background: rgba(0, 0, 0, 0.8)
-        color: white
-        padding: 20px 40px
-        border-radius: 10px
-        z-index: 1000
-        text-align: center
-      ">
-        <div class="spinner" style="
-          border: 4px solid #f3f3f3
-          border-top: 4px solid #3498db
-          border-radius: 50%
-          width: 40px
-          height: 40px
-          animation: spin 1s linear infinite
-          margin: 0 auto 10px
-        "></div>
-        <div>Loading model...</div>
-      </div>
-    `
-    
-    // Add spinner animation
-    const style = document.createElement('style')
-    style.textContent = `
-      @keyframes spin {
-        0% { transform: rotate(0deg) }
-        100% { transform: rotate(360deg) }
-      }
-    `
-    document.head.appendChild(style)
-    document.body.appendChild(indicator)
+  const indicator = document.getElementById('loading-indicator')
+  if (indicator) {
+    indicator.style.display = 'flex'
   }
-  indicator.style.display = 'block'
 }
 
 function hideLoadingIndicator() {
@@ -212,7 +178,7 @@ export function deleteObject() {
         }
 
         const attractorIndex = attractors.findIndex(
-          (a) => (a.parent = draggableObject)
+          (a) => (a.parent === draggableObject)
         )
         if (attractorIndex > -1) {
           attractors.splice(attractorIndex, 1)

--- a/src/js/3d/3dObjects.js
+++ b/src/js/3d/3dObjects.js
@@ -30,9 +30,9 @@ export function addObjectToScene(model) {
     metalness: 0.5, // How metallic the material appears (0 = non-metal, 1 = metal)
     roughness: 0.7, // How rough the surface is (0 = smooth, 1 = rough)
   })
-  
+
   const objLoader = new OBJLoader()
-  
+
   objLoader.load(
     `${model}.obj`,
     // onLoad callback
@@ -62,12 +62,8 @@ export function addObjectToScene(model) {
       scene.add(object)
       models.push(object)
       hideLoadingIndicator()
-      
     },
-
-    function (xhr) {
-      showLoadingIndicator()
-    },
+    showLoadingIndicator(),
 
     // onError callback
     function (error) {
@@ -158,7 +154,7 @@ export function deleteObject() {
         }
 
         const attractorIndex = attractors.findIndex(
-          (a) => (a.parent === draggableObject)
+          (a) => a.parent === draggableObject
         )
         if (attractorIndex > -1) {
           attractors.splice(attractorIndex, 1)

--- a/src/js/3d/3dObjects.js
+++ b/src/js/3d/3dObjects.js
@@ -11,22 +11,6 @@ import {
 import { addAttractorToRack, attractors } from './attractors.js'
 import { scene, models, raycasterMouse, transformControls } from './scene3d.js'
 
-const loadingManager = new THREE.LoadingManager()
-let activeLoads = 0
-
-loadingManager.onStart = function() {
-  showLoadingIndicator()
-}
-
-loadingManager.onLoad = function() {
-  hideLoadingIndicator()
-}
-
-loadingManager.onError = function(url) {
-  console.error('Error loading:', url)
-  hideLoadingIndicator()
-}
-
 /**
  * addObjectToScene loads a 3D object (OBJ format) by its model name.
  *
@@ -39,8 +23,6 @@ export function addObjectToScene(model) {
     console.warn('No model specified, skip loading!')
     return
   }
-  activeLoads++
-  showLoadingIndicator()
 
   // Use a material that responds to light
   let material_obj = new THREE.MeshStandardMaterial({
@@ -49,7 +31,7 @@ export function addObjectToScene(model) {
     roughness: 0.7, // How rough the surface is (0 = smooth, 1 = rough)
   })
   
-  const objLoader = new OBJLoader(loadingManager)
+  const objLoader = new OBJLoader()
   
   objLoader.load(
     `${model}.obj`,
@@ -79,20 +61,18 @@ export function addObjectToScene(model) {
       }
       scene.add(object)
       models.push(object)
+      hideLoadingIndicator()
       
-      activeLoads--
-      if (activeLoads === 0) {
-        hideLoadingIndicator()
-      }
     },
-    undefined, // onProgress - not needed
+
+    function (xhr) {
+      showLoadingIndicator()
+    },
+
     // onError callback
     function (error) {
       console.error(`Error loading ${model}:`, error)
-      activeLoads--
-      if (activeLoads === 0) {
-        hideLoadingIndicator()
-      }
+      hideLoadingIndicator()
     }
   )
 }
@@ -108,7 +88,7 @@ function showLoadingIndicator() {
 function hideLoadingIndicator() {
   const indicator = document.getElementById('loading-indicator')
   if (indicator) {
-    indicator.style.display = 'none'
+    setTimeout(() => (indicator.style.display = 'none'), 100)
   }
 }
 

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -125,3 +125,40 @@ html {
 #shortcutsContent li {
   margin-bottom: 8px;
 }
+
+/* loading spinner */
+#loading-indicator {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.loading-content {
+  background: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 20px 40px;
+  border-radius: 10px;
+  text-align: center;
+}
+
+.spinner {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #3498db;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+  margin: 0 auto 10px;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -159,6 +159,10 @@ html {
 }
 
 @keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }


### PR DESCRIPTION
Previously, if the model path was invalid or no model was selected, the onError callback from OBJLoader didn’t always trigger.
As a result, activeLoads stayed incremented, keeping the loading indicator active in the background.
When trying to add a valid model afterward, the loader no longer appeared since the counter logic was already off.

#### what i have done
[x] - I have added a validation if there is no model to add, then would be no loader.
[x] - Moved the css and the html to their files 

#### How to test:
  Click Add without selecting any model -> the loader should not appear.
  Add a valid model -> the loader should show while loading and hide once finished. 