### PR TITLE
feat: visualize objects in 2d grid

### DIFF
--- a/src/js/3d/pathsTo3d.js
+++ b/src/js/3d/pathsTo3d.js
@@ -27,6 +27,10 @@ function convertPathsTo3D() {
 
   // Convert 2D paths to 3D walls
   paper.project.activeLayer.children.forEach((item) => {
+     if (item.data && item.data.isObjectRectangle) {
+       return // Skip this item - it's an object, not a wall
+     }
+
     if (
       item instanceof paper.Path &&
       item.segments.length >= 2 &&

--- a/src/js/3d/scene3d.js
+++ b/src/js/3d/scene3d.js
@@ -147,7 +147,7 @@ function onMouseClick(event) {
   }
 }
 
-function exportSceneToJson() {
+export function exportSceneToJson() {
   let localPosition = new THREE.Vector3(0, 0, 0)
   let box = new THREE.Box3()
   let size = new THREE.Vector3(0, 0, 0)
@@ -175,6 +175,7 @@ function exportSceneToJson() {
   })
 
   console.log(JSON.stringify(sceneData, null, 2)) // Pretty print JSON with 2-space indent
+  return sceneData
 }
 
 // Add event listener for keypress

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -4,6 +4,7 @@ import { createGrid } from './2d/floor2d.js'
 import { setupDxfUpload } from './2d/dxfLoader.js'
 import { init3D, camera, renderer } from './3d/scene3d.js'
 import { convertPathsTo3D } from './3d/pathsTo3d.js'
+import { drawObjectRectangle } from './2d/floor2d.js'
 // import parseDXF from 'dxf-parser'
 
 createGrid()
@@ -23,6 +24,7 @@ switchButton.addEventListener('click', () => {
   } else {
     container2D.style.display = 'block'
     container3D.style.display = 'none'
+    drawObjectRectangle()
     switchButton.textContent = 'Switch to 3D'
   }
 })


### PR DESCRIPTION
## Visualization of objects in 3D-canvas in 2D paper.js canvas

<img width="1919" height="930" alt="image" src="https://github.com/user-attachments/assets/9f847135-3b1d-411d-9821-473f2965985b" />

### Features
- [X] You can change the position of the objects in 3D-canvas or even delete them, it will automatically updates the 2D-grid.
- [X] Color-coded object types (tables, chairs, coolers, racks) for easy identification in 2D view.

### Considerations
- Object rectangles in 2D view use fixed size (50x50px) and don't reflect actual object dimensions yet
- This is a work in progress and will continue to be developed until it is fully functional, definitely will push more commits to this PR.